### PR TITLE
Add abbreviation for ROAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ambients Encoding Examples
 
-Examples of computation abstractions using the [Robust Ambient](https://pdfs.semanticscholar.org/c847/a9bb262c87bffcae9b5e2dca5dcf88551ea2.pdf) calculus.
+Examples of computation abstractions using the [Robust Ambient](https://pdfs.semanticscholar.org/c847/a9bb262c87bffcae9b5e2dca5dcf88551ea2.pdf) calculus *(abbrv. ROAM)*.
 
 ## Encodings
 


### PR DESCRIPTION
This PR adds abbreviation definition for Robust Ambients (ROAM) in the readme.