### PR TITLE
Corrected the final value of monoid reduction

### DIFF
--- a/monoids/README.md
+++ b/monoids/README.md
@@ -51,11 +51,13 @@ Reduces to a final value:
 
 ```
 string[
-  left[
-    string[hello[]]
-  ]|
-  right[
-    string[world[]]
+  concat[
+    left[
+      string[hello[]]
+    ]|
+    right[
+      string[world[]]
+    ]
   ]
 ]
 ```


### PR DESCRIPTION
The intermediate `concat`-ambient was missing from the value structure in README.